### PR TITLE
add rake task to export list of broken dropbox image links

### DIFF
--- a/lib/tasks/export_offline_images_list.rake
+++ b/lib/tasks/export_offline_images_list.rake
@@ -1,0 +1,30 @@
+desc "export list of offline images in public lessons"
+task :export_offline_images_list => [:environment] do
+  filename = File.join(Rails.root.join('tmp'), 'offline-images.txt')
+  File.open(filename, 'w') do |file|          
+    Course.all.each do |course|
+      if course.public
+        file.puts("")
+        file.puts("COURSE: #{course.name.upcase}")
+        course.sections.each do |section|
+          if section.public
+            section.lessons.each do |lesson|
+              if lesson.public && lesson.content.include?("dropbox")
+                links = lesson.content.scan(/(\/\/dl\.dropbox.*?)\)/)
+                links.each do |link|
+                  url = "http:" + link[0]
+                  response_code = HTTParty.get(url).code
+                  if response_code != 200
+                    file.puts("#{section.name.upcase} | #{lesson.name}:")
+                    file.puts(link[0])
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  puts "Exported to #{filename.to_s}"
+end


### PR DESCRIPTION
Rake task to export a list of all broken image links on public LHTP lessons. I wrote it to be run on a local copy of DB.