### PR TITLE
add rake task for generating a list of broken dropbox image links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'bootstrap-sass'
 gem 'bootswatch-rails'
 gem 'bootstrap-multiselect-rails'
 gem 'sass-rails'
+gem 'httparty'
 
 group :development do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hirb (0.7.3)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
@@ -121,6 +123,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    multi_xml (0.5.5)
     newrelic_rpm (3.16.2.321)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -256,6 +259,7 @@ DEPENDENCIES
   factory_girl_rails
   friendly_id
   hirb
+  httparty
   jquery-rails
   jquery-ui-rails
   launchy
@@ -283,4 +287,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/lib/tasks/export_offline_images_list.rake
+++ b/lib/tasks/export_offline_images_list.rake
@@ -1,0 +1,30 @@
+desc "export list of offline images in public lessons"
+task :export_offline_images_list => [:environment] do
+  filename = File.join(Rails.root.join('tmp'), 'offline-images.txt')
+  File.open(filename, 'w') do |file|          
+    Course.all.each do |course|
+      if course.public
+        file.puts("")
+        file.puts("COURSE: #{course.name.upcase}")
+        course.sections.each do |section|
+          if section.public
+            section.lessons.each do |lesson|
+              if lesson.public && lesson.content.include?("dropbox")
+                links = lesson.content.scan(/(\/\/(dl|www)\.dropbox.*?)\)/)
+                links.each do |link|
+                  url = "http:" + link[0]
+                  response_code = HTTParty.head(url).code
+                  if response_code != 200
+                    file.puts("#{section.name.upcase} | #{lesson.name}:")
+                    file.puts(link[0])
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  puts "Exported to #{filename.to_s}"
+end


### PR DESCRIPTION
Rake task to go through all public lessons and generate a list of any broken links to images on Dropbox. Intended to be run on local copy of DB.
