### PR TITLE
fix lesson reorder bug when lesson belongs to multiple sections

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -67,9 +67,9 @@ private
   end
 
   def update_lesson_order
-    lesson_sections = LessonSection.where(lesson_id: @course.lessons.pluck(:id), section_id: @course.sections.pluck(:id))
-    params[:course][:lessons_attributes].each do |lesson|
-      lesson_sections.find_by(lesson_id: lesson[1][:id]).update(number: lesson[1][:number])
+    params[:course][:lesson_sections_attributes].each do |lesson_section_params|
+      lesson_section = LessonSection.find(lesson_section_params[1][:id])
+      lesson_section.update(number: lesson_section_params[1][:number])
     end
   end
 end

--- a/app/views/sections/_section.html.erb
+++ b/app/views/sections/_section.html.erb
@@ -40,9 +40,9 @@
         <% end %>
 
         <% if can? :update, Lesson %>
-          <%= f.fields_for 'lessons_attributes[]', lesson do |lesson_form| %>
-            <%= lesson_form.hidden_field :id %>
-            <%= lesson_form.hidden_field :number, { value: LessonSection.find_by(section_id: section.id, lesson_id: lesson.id).number, class: :lesson } %>
+          <%= f.fields_for 'lesson_sections_attributes[]', LessonSection.find_by(section_id: section.id, lesson_id: lesson.id) do |lesson_section_form| %>
+            <%= lesson_section_form.hidden_field :id %>
+            <%= lesson_section_form.hidden_field :number, { value: LessonSection.find_by(section_id: section.id, lesson_id: lesson.id).number, class: :lesson } %>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
When lesson belongs to multiple sections, reordering had bug where it would give all of the LessonSections the number that should go to the last one.